### PR TITLE
fix issue #4

### DIFF
--- a/game/tournament.py
+++ b/game/tournament.py
@@ -140,7 +140,8 @@ class Tournament:
         err = None
         boards = []
         if key in self.player_keys:
-            boards.append(self.player_games[key].prepared_for(key).contents)
+            if self.player_games[key] != None:
+                boards.append(self.player_games[key].prepared_for(key).contents)
         elif key == self.observe_key:
             board_objs = self.boards.copy()
             for obj in board_objs:


### PR DESCRIPTION
Fixes #4.

If a player isn't in an active game, `/boards/key` returns a response with the `boards` field as an empty array (instead of an internal error).