### PR TITLE
add delay between board reaching win/loss and it being reassigned

### DIFF
--- a/game/othello.py
+++ b/game/othello.py
@@ -1,6 +1,7 @@
 from enum import Enum
 import itertools
 import copy
+import time
 
 from flask import json
 
@@ -39,6 +40,11 @@ class Board:
         self.tied = False
 
         self.is_open = True
+        # time at which countdown to setting is_open begins
+        self.open_countdown_start = 0.0
+
+        # time to run countdown till setting is_open
+        self.open_countdown_time = 5.0 #seconds
     
     def __str__(self):
         string = ""
@@ -52,12 +58,21 @@ class Board:
     def game(self):
         return (self.player1_key, self.player2_key)
 
-    def ready(self):
-        self.is_open = True
+    def ready_start_countdown(self):
         self.winner = None
         self.loser = None
         self.tied = False
         self.active_turn = PLAYER1
+        self.open_countdown_start = time.time()
+        self.is_open = False
+
+    def ready_run_countdown(self):
+        if self.open_countdown_start == 0.0:
+            return
+
+        if time.time() - self.open_countdown_start > self.open_countdown_time:
+            self.is_open = True
+            self.open_countdown_start = 0.0
 
     def load_game(self, game):
         self.contents = [[EMPTY for y in range(8)] for x in range(8)]

--- a/game/tournament.py
+++ b/game/tournament.py
@@ -81,13 +81,12 @@ class Tournament:
         self.running = True
         print(f"Tournament started, updating every {self.update_interval} seconds")
         while self.running:
-            t = time.time()
-            if t - last_update < self.update_interval:
-                continue
-            last_update = t
+            time.sleep(self.update_interval)
 
             # handle finished boards
             for b in self.boards:
+                b.ready_run_countdown()
+
                 if b.tied:
                     self.player_records[b.player1_key].ties += 1
                     self.player_records[b.player2_key].ties += 1
@@ -101,7 +100,7 @@ class Tournament:
                 self.player_games[b.player1_key] = None
                 self.player_games[b.player2_key] = None
                 print("Readying board")
-                b.ready()
+                b.ready_start_countdown()
 
             # handle available boards
             available_boards = [b for b in self.boards if b.is_open]


### PR DESCRIPTION
Adds a 5 second delay between when a board reaches a win/loss/tie state and when it is reassigned to another match.

This allows for the end state of a match to be examined by humans watching the match. Previously, the last move and the ending state of the game couldn't be seen, because the board would be immediately reassigned.